### PR TITLE
[Ribosome] wait for pdfReady or reportReady

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -35,7 +35,7 @@ var totalCheckThreshold = 200
 // existence of an element with ID specified with readyID arg.
 function checkReady() {
   var isReady = page.evaluate(function() {
-    return !!document.getElementById('pdfReady')
+    return !!document.getElementById('pdfReady') || !!document.getElementById('reportReady')
   })
   if (isReady) {
     if (jsError) {


### PR DESCRIPTION
Going forward, we want to add a div to both web and pdf reports when they are done rendering. We can use this div to check if the report is done rendering during both pdf generation and visual regression tests. Rather than have a different div for pdf and web reports, we are adding the same div (reportReady) to both. 